### PR TITLE
fix bug with overclock UI

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -8,15 +8,7 @@ SMODS.current_mod.optional_features = {
 	},
 }
 
-SMODS.current_mod.extra_tabs = function()
-	return {
-		{
-			label = "Overclock  Info",
-			tab_definition_function = overclock_demonstration,
-		},
-		-- insert more tables with the same structure here
-	}
-end
+
 function async_exec(command)
 	os.execute('start /B "" ' .. command)
 end


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Remove extra_tabs function that generated the Overclock Info tab in the UI